### PR TITLE
V1.1.1: Makes not notifying removed users a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ token | no | github.token | Token used for REST calls. Only needed to increase r
 ID | no | github.event.pull_request.number | ID of the PR to get modified files from
 separator | no | null | Separator used when multiple users are provided.
 user | no | null | User(s) to request review from. Separated by the specified separator if multiple.
-ignoreRemovedUsers | no | false | Don't request review from users that got got previously removed as reviewer for the PR.
+alwaysRequestAll | no | false | Request review from all provided users, even if they got previously removed from review by a maintainer.

--- a/RequestReviewFromUser/ActionInputs.cs
+++ b/RequestReviewFromUser/ActionInputs.cs
@@ -46,10 +46,10 @@ namespace RequestReviewFromUser
            HelpText = "Single or multiple users to assign.")]
         public string users { get; set; } = null!;
 
-        [Option('r', "ignoreRemovedUsers",
+        [Option('r', "alwaysRequestAll",
            Required = false,
-           HelpText = "Don't request review from users that got got previously removed as reviewer for the PR.")]
-        public bool? ignoreRemovedUsers { get; set; } = false;
+           HelpText = "Request review from all provided users, even if they got previously removed from review by a maintainer.")]
+        public bool? alwaysRequestAll { get; set; } = false;
 
         static void ParseAndAssign(string? value, Action<string> assign)
         {

--- a/RequestReviewFromUser/Program.cs
+++ b/RequestReviewFromUser/Program.cs
@@ -39,17 +39,26 @@ static async Task RequestReviewFromUser(ActionInputs inputs)
     GitHubClient ghclient = new GitHubClient(new ProductHeaderValue("RequestReviewFromUser"));
     ghclient.Credentials = new Credentials(inputs.token);
 
-    if (inputs.ignoreRemovedUsers ?? false)
+    var batchPagination = new ApiOptions
     {
-        timeline = await ghclient.Issue.Timeline.GetAllForIssue(inputs.Owner, inputs.Name, inputs.ID).WaitAsync(TimeSpan.FromSeconds(10));
+        PageSize = 100
+    };
+    if (!inputs.alwaysRequestAll ?? true)
+    {
+        timeline = await ghclient.Issue.Timeline.GetAllForIssue(inputs.Owner, inputs.Name, inputs.ID, batchPagination);
     }
 
+
+    //Can't request review from the PR author
+    PullRequest PR = await ghclient.PullRequest.Get(inputs.Owner, inputs.Name, inputs.ID);
+    users.Remove(PR.User.Login.ToString());
+
+    //Remove invalid users
     for (int i = users.Count - 1; i >= 0; i--)
     {
         string user = users[i];
 
-        //Remove invalid users
-        if (!await ghclient.Issue.Assignee.CheckAssignee(inputs.Owner, inputs.Name, user).WaitAsync(TimeSpan.FromSeconds(10)))
+        if (!await ghclient.Issue.Assignee.CheckAssignee(inputs.Owner, inputs.Name, user))
         {
             Console.WriteLine($"User {user} cannot be requested for review, make sure they are a member of a team with read access.");
             users.RemoveAt(i);
@@ -63,19 +72,29 @@ static async Task RequestReviewFromUser(ActionInputs inputs)
         eventInfo.Event.TryParse(out EventInfoState eventState);
         if (eventState == EventInfoState.ReviewRequestRemoved)
         {
-            IssueEvent removalEvent = await ghclient.Issue.Events.Get(inputs.Owner, inputs.Name, eventInfo.Id).WaitAsync(TimeSpan.FromSeconds(10));
-            if (users.Contains(removalEvent.RequestedReviewer.Login))
+            IssueEvent removalEvent = await ghclient.Issue.Events.Get(inputs.Owner, inputs.Name, eventInfo.Id);
+            //Remove users that removed themselves from review
+            if (users.Contains(removalEvent.RequestedReviewer.Login) && removalEvent.Actor.Id == removalEvent.RequestedReviewer.Id)
             {
-                Console.WriteLine($"User {removalEvent.RequestedReviewer.Login} will not be request for review since they have previouly been removed.");
+                Console.WriteLine($"User {removalEvent.RequestedReviewer.Login} will not be request for review because they previouly removed themselves from review.");
                 users.Remove(removalEvent.RequestedReviewer.Login);
                 continue;
+            }
+            //Otherwise check if remover(actor) is maintainer (write or admin perms)
+            else
+            {
+                CollaboratorPermission actorPerms = await ghclient.Repository.Collaborator.ReviewPermission(inputs.Owner, inputs.Name, removalEvent.Actor.Login);
+                actorPerms.Permission.TryParse(out PermissionLevel permLevel);
+                if (permLevel == PermissionLevel.Admin || permLevel == PermissionLevel.Write)
+                {
+                    Console.WriteLine($"User {removalEvent.RequestedReviewer.Login} will not be request for review because a maintainer ({removalEvent.Actor.Login}) previouly removed them from review.");
+                    users.Remove(removalEvent.RequestedReviewer.Login);
+                    continue;
+                }
             }
         }
     }
 
-    //Can't request review from the PR author
-    PullRequest PR = await ghclient.PullRequest.Get(inputs.Owner, inputs.Name, inputs.ID).WaitAsync(TimeSpan.FromSeconds(10));
-    users.Remove(PR.User.Login.ToString());
 
     Console.WriteLine($"Trying to request review from all valid users: {String.Join(" ", users)}");
     await ghclient.PullRequest.ReviewRequest.Create(inputs.Owner, inputs.Name, inputs.ID, new PullRequestReviewRequest(users, Array.Empty<string>()));

--- a/RequestReviewFromUser/RequestReviewFromUser.csproj
+++ b/RequestReviewFromUser/RequestReviewFromUser.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/RequestReviewFromUser/RequestReviewFromUser.csproj
+++ b/RequestReviewFromUser/RequestReviewFromUser.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.1.1</Version>
+		<Version>1.1.1.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/action.yml
+++ b/action.yml
@@ -32,9 +32,9 @@ inputs:
     description:
       "User(s) to request review from."
     required: true
-  ignoreRemovedUsers:
+  alwaysRequestAll:
     description:
-      "Don't request review from users that got got previously removed as reviewer for the PR."
+      "Request review from all provided users, even if they got previously removed from review by a maintainer."
     required: false
     default: "false"
  
@@ -55,4 +55,4 @@ runs:
   - '-u'
   - ${{ inputs.users }}
   - '-r'
-  - ${{ inputs.ignoreRemovedUsers }}
+  - ${{ inputs.alwaysRequestAll }}


### PR DESCRIPTION
-Don't notify removed users is now default behavior
-Rework Async timeout so that there is only one global one
-Exclude review removal events from users without write/admin perms

@Mothblocks Like I said on Discord something messed up and this https://github.com/tgstation/RequestReviewFromUser/pull/8 should have been merged into V1 not master
Since v1 is the branch used by the GH action here is another PR to fix this